### PR TITLE
changes to fix `error: cannot convert ‘const value_type*’`

### DIFF
--- a/src/cc/dapps/subatomic_utils.cpp
+++ b/src/cc/dapps/subatomic_utils.cpp
@@ -120,7 +120,7 @@ bool get_conf_content(const std::string& ticker, std::vector<std::string>& vec_o
     auto tmp = fs::path(path) / ticker / (ticker + ".conf");
     free(path);
 #ifndef NATIVE_WINDOWS
-    path = strdup(tmp.c_str());
+    path = strdup(tmp.string().c_str());
 #else
     path = _strdup((const char *)tmp.c_str());
 #endif // !NATIVE_WINDOWS

--- a/src/cc/dapps/subatomic_utils.cpp
+++ b/src/cc/dapps/subatomic_utils.cpp
@@ -87,9 +87,9 @@ char* get_komodo_config_path()
   fs::path conf_root = fs::path(std::getenv("HOME")) / ".komodo/komodo.conf";
   #endif
 #ifndef NATIVE_WINDOWS
-  return strdup(conf_root.c_str());
+  return strdup(conf_root.string().c_str());
 #else
-  return _strdup((const char *)conf_root.c_str());
+  return _strdup((const char *)conf_root.string().c_str());
 #endif // !NATIVE_WINDOWS
 
   
@@ -104,9 +104,9 @@ char* get_komodo_config_parent_path()
   fs::path conf_root = fs::path(std::getenv("HOME")) / ".komodo";
   #endif
 #ifndef NATIVE_WINDOWS
-  return strdup(conf_root.c_str());
+  return strdup(conf_root.string().c_str());
 #else
-  return _strdup((const char*)conf_root.c_str());
+  return _strdup((const char*)conf_root.string().c_str());
 #endif // !NATIVE_WINDOWS
 }
 


### PR DESCRIPTION
Fix for:

```
+ make subatomic_win
x86_64-w64-mingw32-g++-posix -c -std=c++17 -Wfatal-errors -Wall -Wextra -Werror subatomic_utils.cpp
subatomic_utils.cpp: In function ‘char* get_komodo_config_path()’:
subatomic_utils.cpp:89:32: error: cannot convert ‘const value_type*’ {aka ‘const wchar_t*’} to ‘const char*’
   89 |   return strdup(conf_root.c_str());
      |                 ~~~~~~~~~~~~~~~^~
      |                                |
      |                                const value_type* {aka const wchar_t*}
compilation terminated due to -Wfatal-errors.
make: *** [Makefile:21: subatomic_win] Error 1
##[error]Process completed with exit code 2.
```